### PR TITLE
Fixed "Undefined property: Closure::$name" error

### DIFF
--- a/resources/views/filament/message-from.blade.php
+++ b/resources/views/filament/message-from.blade.php
@@ -1,7 +1,7 @@
 <div class="flex gap-4">
-    <img class="w-9 h-9 rounded-full" src="https://ui-avatars.com/api/?name={{ urlencode($getRecord->name) }}'&color=FFFFFF&background=111827" alt="{{ $getRecord->email }}"/>
+    <img class="w-9 h-9 rounded-full" src="https://ui-avatars.com/api/?name={{ urlencode($getRecord()->name) }}'&color=FFFFFF&background=111827" alt="{{ $getRecord()->email }}"/>
     <p class="flex flex-col">
-        <span>{{ $getRecord->name }}</span>
-        <span class="text-xs">{{ $getRecord->email }}</span>
+        <span>{{ $getRecord()->name }}</span>
+        <span class="text-xs">{{ $getRecord()->email }}</span>
     </p>
 </div>


### PR DESCRIPTION
Running on PHP8.1 and Filament v2.16.38, I received error: "Undefined property: Closure::$name" when listing Letters. Changing $getRecord->name to $getRecord()->name (similar change for 'email' too), make the page work.